### PR TITLE
Add support for unix domain socket client

### DIFF
--- a/include/tcp/address.h
+++ b/include/tcp/address.h
@@ -42,6 +42,9 @@ protected:
             // check family
             if (u.s.sa_family == AF_INET6) return Net::Address(Net::Ip(u.v6.sin6_addr), ntohs(u.v6.sin6_port));
             if (u.s.sa_family == AF_INET) return Net::Address(Net::Ip(u.v4.sin_addr), ntohs(u.v4.sin_port));
+
+            // basically a hack because Net::Address doesn't support unix domain address
+            if (u.s.sa_family == AF_LOCAL) return Net::Address(Net::Ip("127.0.0.1"), 0);
         }
     
         // default invalid address

--- a/test/sock_un.cpp
+++ b/test/sock_un.cpp
@@ -1,0 +1,67 @@
+/**
+ *  socket_un.cpp
+ *
+ *  Unix Domain socket related tests
+ *
+ *  @copyright 2014 Copernica BV
+ */
+
+#include <thread>
+#include <chrono>
+#include <../reactcpp.h>
+#include <gtest/gtest.h>
+
+TEST(UnixDomainSocket, ClientTest)
+{
+    const char PATH[] = "/tmp/sock.reactcpp.test";
+    const char SERVER_TX_MSG[] = "SERVER HELLO";
+    const char CLIENT_TX_MSG[] = "CLIENT HELLO";
+
+    using React::Tcp::Server;
+    using React::Tcp::Connection;
+
+    char server_rx_msg[64] = {0};
+    char client_rx_msg[64] = {0};
+
+    React::MainLoop loop;
+
+    Server server(&loop, PATH);
+    std::shared_ptr<Connection> conn1;
+
+    server.onConnect([&]() -> bool {
+        conn1 = std::shared_ptr<Connection>(new Connection(&server));
+
+        conn1->onReadable([&]() -> bool {
+            conn1->recv(server_rx_msg, sizeof(server_rx_msg));
+            conn1->send(SERVER_TX_MSG, sizeof(SERVER_TX_MSG), 0);
+            loop.stop();
+            return false;
+        });
+
+        return false;
+    });
+
+    std::thread th([&]() {
+        React::Loop inner;
+        Connection client1(&inner, PATH);
+
+        client1.onWritable([&]() -> bool {
+            client1.send(CLIENT_TX_MSG, sizeof(CLIENT_TX_MSG), 0);
+            return false;
+        });
+
+        client1.onReadable([&]() -> bool {
+            client1.recv(client_rx_msg, sizeof(client_rx_msg));
+            return false;
+        });
+
+        inner.run();
+    });
+
+    loop.run();
+    th.join();
+
+    ASSERT_STREQ(CLIENT_TX_MSG, server_rx_msg);
+    ASSERT_STREQ(SERVER_TX_MSG, client_rx_msg);
+}
+


### PR DESCRIPTION
Fixes CopernicaMarketingSoftware/REACT-CPP#9.
Some changes are hackish because Net::Address doesn't support unix domain address - I would request you to kind review if this is ok. Feel free to request any modifications.