### PR TITLE
Makefile: Cleanup compiler and linker flags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,8 @@
-CPP		= g++
+AR		= ar
+CXX		= g++
 RM		= rm -f
-CPPFLAGS	= -Wall -MMD -c -I. -std=c++11
-LD		= g++
-LD_FLAGS	= -Wall -shared
+MY_CXXFLAGS	= -Wall -MMD -c -I. -std=c++11
+MY_LDFLAGS	= -Wall -shared
 SHARED_LIB	= lib$(LIBRARY_NAME).so.$(VERSION)
 STATIC_LIB	= lib$(LIBRARY_NAME).a.$(VERSION)
 STATIC_FPIC_LIB = lib$(LIBRARY_NAME)_fpic.a
@@ -11,12 +11,12 @@ DEPENDENCIES    = $(SOURCES:%.cpp=%.d)
 SHARED_OBJECTS	= $(SOURCES:%.cpp=%.o)
 STATIC_OBJECTS	= $(SOURCES:%.cpp=%.s.o)
 
-all:	CPPFLAGS += -g
-all:	LD_FLAGS += -g
+all:	CXXFLAGS = -g
+all:	LDFLAGS = -g
 all:	shared static
 
-release:	CPPFLAGS += -O2
-release:	LD_FLAGS += -O2
+release:	CXXFLAGS = -O2
+release:	LDFLAGS = -O2
 release:	shared static
 
 -include ${DEPENDENCIES}
@@ -28,20 +28,20 @@ static_fpic: ${SHARED_OBJECTS} ${STATIC_FPIC_LIB}
 static:	${STATIC_OBJECTS} ${STATIC_LIB}
 
 ${SHARED_LIB}: ${SHARED_OBJECTS}
-	${LD} ${LD_FLAGS} -Wl,-soname,lib$(LIBRARY_NAME).so.$(SONAME) -o $@ ${SHARED_OBJECTS} -lev -lcares
+	${CXX} ${MY_LDFLAGS} ${LDFLAGS} -Wl,-soname,lib$(LIBRARY_NAME).so.$(SONAME) -o $@ ${SHARED_OBJECTS} -lev -lcares
 
 ${STATIC_LIB}: ${STATIC_OBJECTS}
-	ar rcs ${STATIC_LIB} ${STATIC_OBJECTS}
+	$(AR) rcs ${STATIC_LIB} ${STATIC_OBJECTS}
 
 ${STATIC_FPIC_LIB}: ${SHARED_OBJECTS}
-	ar rcs ${STATIC_FPIC_LIB} ${SHARED_OBJECTS}
+	$(AR) rcs ${STATIC_FPIC_LIB} ${SHARED_OBJECTS}
 
 clean:
 	${RM} *.obj *~* ${SHARED_OBJECTS} ${STATIC_OBJECTS} ${SHARED_LIB} ${STATIC_LIB}
 
 ${SHARED_OBJECTS}:
-	${CPP} ${CPPFLAGS} -fpic -o $@ ${@:%.o=%.cpp}
+	${CXX} ${CXXFLAGS} ${CPPFLAGS} ${MY_CXXFLAGS} -fpic -o $@ ${@:%.o=%.cpp}
 
 ${STATIC_OBJECTS}:
-	${CPP} ${CPPFLAGS} -o $@ ${@:%.s.o=%.cpp}
+	${CXX} ${CXXFLAGS} ${CPPFLAGS} ${MY_CXXFLAGS} -o $@ ${@:%.s.o=%.cpp}
 


### PR DESCRIPTION
Cleanup compiler and linker flags, so the library can be easily
cross-compiled by overwriting CPPFLAGS, CXXFLAGS and LDFLAGS:

* Rename CPP into CXX, as we use this command for compiling, not
  preprocessing.
* Remove separate LD usage, use CXX instead. This is to still launch
  compiler command when user overrides CXX and LD commands.
* Define MY_CXXFLAGS and MY_LDFLAGS, which should always take place and
  not get overridden by user.
* Define AR command, which can be overidden by user.